### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node app.js"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # webappdevca
 Web App Development Final CA
+[![Run on Repl.it](https://repl.it/badge/github/robertsoldan/webappdevca)](https://repl.it/github/robertsoldan/webappdevca)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Robb1010/webappdevca).